### PR TITLE
Add ability to remove error listeners from parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -53,6 +53,7 @@ pub trait Parser<'input>: Recognizer<'input> {
     fn add_error_listener(&mut self, listener: Box<dyn ErrorListener<'input, Self>>)
     where
         Self: Sized;
+    fn remove_error_listeners(&mut self);
     fn notify_error_listeners(
         &self,
         msg: String,
@@ -291,6 +292,8 @@ where
     fn add_error_listener(&mut self, listener: Box<dyn ErrorListener<'input, Self>>) {
         self.error_listeners.borrow_mut().push(listener)
     }
+
+    fn remove_error_listeners(&mut self) { self.error_listeners.borrow_mut().clear(); }
 
     fn notify_error_listeners(
         &self,


### PR DESCRIPTION
Now there is no ability to remove ConsoleErrorListener from parser. With new method it can be done.