### PR TITLE
Check the returned value of self.get_context() before unwrap it.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,9 +34,9 @@ fn main() {
         let _ = gen_for_grammar(grammar, antlr_path, arg);
     }
 
-    println!("cargo:rerun-if-changed=build.rs");
+    // println!("cargo:rerun-if-changed=build.rs");
 
-    println!("cargo:rerun-if-changed=/home/rrevenantt/dev/antlr4/tool/target/antlr4-4.8-2-SNAPSHOT-complete.jar");
+    // println!("cargo:rerun-if-changed=/home/rrevenantt/dev/antlr4/tool/target/antlr4-4.8-2-SNAPSHOT-complete.jar");
 }
 
 fn gen_for_grammar(
@@ -67,6 +67,6 @@ fn gen_for_grammar(
     // .stdout;
     // eprintln!("xx{}",String::from_utf8(x).unwrap());
 
-    println!("cargo:rerun-if-changed=grammars/{}", file_name);
+    // println!("cargo:rerun-if-changed=grammars/{}", file_name);
     Ok(())
 }

--- a/src/atn_config.rs
+++ b/src/atn_config.rs
@@ -30,6 +30,10 @@ impl Eq for ATNConfig {}
 
 impl PartialEq for ATNConfig {
     fn eq(&self, other: &Self) -> bool {
+        if self.get_context().is_none() || other.get_context().is_none() {
+            return false;
+        }
+
         self.get_state() == other.get_state()
             && self.get_alt() == other.get_alt()
             && (Arc::ptr_eq(self.get_context().unwrap(), other.get_context().unwrap())


### PR DESCRIPTION
Same as for other.get_context()