### PR TITLE
Fix generated code for PlSqlParser.g4

### DIFF
--- a/templates/Rust.stg
+++ b/templates/Rust.stg
@@ -498,7 +498,7 @@ antlr_rust::tid!{<currentRule.ctxType>All\<'a>}
 
 impl\<'input> antlr_rust::parser_rule_context::DerefSeal for <currentRule.ctxType>All\<'input>{}
 
-impl\<'input> <parser.grammarName>ParserContext\<'input> for <currentRule.ctxType>All\<'input>{}
+impl\<'input> <parser.name>Context\<'input> for <currentRule.ctxType>All\<'input>{}
 
 impl\<'input> Deref for <currentRule.ctxType>All\<'input>{
 	type Target = dyn <currentRule.ctxType>Attrs\<'input> + 'input;


### PR DESCRIPTION
When building the PlSql grammar from https://github.com/antlr/grammars-v4/blob/master/sql/plsql/PlSqlParser.g4 and https://github.com/antlr/grammars-v4/blob/master/sql/plsql/PlSqlLexer.g4, the generated Rust code fails to compile with the following error.
```
error[E0405]: cannot find trait `PlSqlParserParserContext` in this scope
      --> tests/gen/plsqlparser.rs:112704:14
       |
4550   | / pub trait PlSqlParserContext<'input>:
4551   | |     for<'x> Listenable<dyn PlSqlParserListener<'input> + 'x > + 
4552   | |     ParserRuleContext<'input, TF=LocalTokenFactory<'input>, Ctx=PlSqlParserContextType>
4553   | | {}
       | |__- similarly named trait `PlSqlParserContext` defined here
...
112704 |   impl<'input> PlSqlParserParserContext<'input> for Table_ref_aux_internalContextAll<'input>{}
       |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: a trait with a similar name exists: `PlSqlParserContext`
```

The PlSqlParser.g4 and PlSqlLexer.g4 files need to modified to remove references to self. You can find the modified version at:
https://github.com/peteromoon/antlr4rust/blob/plsqltest/grammars/PlSqlLexer.g4 and https://github.com/peteromoon/antlr4rust/blob/plsqltest/grammars/PlSqlParser.g4.

