### PR TITLE
Update uuid version definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/build.rs","/grammars","/templates"]
 
 [dependencies]
 lazy_static = "^1.4"
-uuid = "=0.8.*"
+uuid = { version = ">=0.8.2, <2.0.0", features = ["serde", "v4"] }
 byteorder = "^1"
 murmur3 = "=0.4" # 0.5 is incompatible currently
 bit-set = "=0.5.*"


### PR DESCRIPTION
Since uuid >= 1.0 exists now it would be nice to make the uuid version a little more versatile. The proposed change fixes uuid version mismatches when using this crate with together with uuid >= 1.0.