### PR TITLE
fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or if you want to contribute to only runtime part you don't have to do build it 
 
 But if you want to build or change generator yourself:
 * `git clone -b rust-target https://github.com/rrevenantt/antlr4` - clone my antlr4 fork  
-* `git submodule update --init --recursive` - update Rust target submodule
+* `git submodule update --init --recursive --remote` - update Rust target submodule
 * `mvn -DskipTests install` - build generator
 
 ### Implementation status


### PR DESCRIPTION
fix #52 
If you want to lean more about this issue check : https://stackoverflow.com/a/1032653  

From git version 1.8.3 to the latest version.
`git submodule update --init --recursive` will not check out the uptodate submodule.
`--remote` is required  

Building without `--remote` fetch the old Rust.stg template and the visitor feature introduce in V0.3 will not work.  
Nevetheless the released V0.3.0 asset antlr4-4.8-2-SNAPSHOT-complete.jar is OK which is a bit surprising. 