### PR TITLE
Allow access to Ext from base parser

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -147,7 +147,7 @@ pub struct BaseParser<
     _syntax_errors: Cell<isize>,
     error_listeners: RefCell<Vec<Box<dyn ErrorListener<'input, Self>>>>,
 
-    ext: Ext,
+    pub ext: Ext,
     pd: PhantomData<fn() -> &'input str>,
 }
 


### PR DESCRIPTION
Hi! In my parser, I need access to a field in the Ext of the generated grammar. Would it be ok to just make that filed public? Thank you very much!