### PR TITLE
Fix CommonTokenStream when first token is hidden

### DIFF
--- a/src/common_token_stream.rs
+++ b/src/common_token_stream.rs
@@ -106,7 +106,8 @@ impl<'input, T: TokenSource<'input>> CommonTokenStream<'input, T> {
             base: UnbufferedTokenStream::new_buffered(lexer),
             channel,
         };
-        r.sync(0);
+        let i = r.next_token_on_channel(0, channel, 1);
+        r.base.seek(i);
         r
     }
 


### PR DESCRIPTION
Intended to fix #66 