### PR TITLE
refactor: remove once_cell dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ uuid = "=0.8.*"
 byteorder = "^1"
 murmur3 = "=0.4" # 0.5 is incompatible currently
 bit-set = "=0.5.*"
-once_cell = "^1.2"
 #backtrace = "=0.3"
 typed-arena = "^2.0"
 better_any = "0.2.0-dev.1"

--- a/src/atn_state.rs
+++ b/src/atn_state.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 use crate::interval_set::IntervalSet;
 use crate::transition::Transition;
@@ -73,7 +73,7 @@ pub trait ATNState: Sync + Send + Debug {
     fn get_rule_index(&self) -> usize;
     fn set_rule_index(&self, v: usize);
 
-    fn get_next_tokens_within_rule(&self) -> &OnceCell<IntervalSet>;
+    fn get_next_tokens_within_rule(&self) -> &OnceLock<IntervalSet>;
     //    fn set_next_token_within_rule(&mut self, v: IntervalSet);
 
     fn get_state_type(&self) -> &ATNStateType;
@@ -91,7 +91,7 @@ pub trait ATNState: Sync + Send + Debug {
 
 #[derive(Debug)]
 pub struct BaseATNState {
-    next_tokens_within_rule: OnceCell<IntervalSet>,
+    next_tokens_within_rule: OnceLock<IntervalSet>,
 
     //    atn: Box<ATN>,
     epsilon_only_transitions: bool,
@@ -110,7 +110,7 @@ pub struct BaseATNState {
 impl BaseATNState {
     pub fn new_base_atnstate() -> BaseATNState {
         BaseATNState {
-            next_tokens_within_rule: OnceCell::new(),
+            next_tokens_within_rule: OnceLock::new(),
             epsilon_only_transitions: false,
             rule_index: 0,
             state_number: 0,
@@ -133,7 +133,7 @@ impl ATNState for BaseATNState {
         unimplemented!()
     }
 
-    fn get_next_tokens_within_rule(&self) -> &OnceCell<IntervalSet> {
+    fn get_next_tokens_within_rule(&self) -> &OnceLock<IntervalSet> {
         &self.next_tokens_within_rule
     }
 


### PR DESCRIPTION
Remove once_cell deps now that the `once_cell::sync::OnceCell` functionalities are in `std::sync::OnceLock`

Built and tested with `cargo build` and `cargo test`.

Issue: #90 